### PR TITLE
possible fix for issues with rebased number

### DIFF
--- a/src/collab.js
+++ b/src/collab.js
@@ -122,9 +122,8 @@ export function receiveTransaction(state, steps, clientIDs) {
   if (!steps.length)
     return state.tr.setMeta(collabKey, new CollabState(version, unconfirmed))
 
-  let nUnconfirmed = unconfirmed.length
   let tr = state.tr
-  if (nUnconfirmed) {
+  if (unconfirmed.length) {
     unconfirmed = rebaseSteps(unconfirmed, steps, tr)
   } else {
     for (let i = 0; i < steps.length; i++) tr.step(steps[i])
@@ -132,7 +131,7 @@ export function receiveTransaction(state, steps, clientIDs) {
   }
 
   let newCollabState = new CollabState(version, unconfirmed)
-  return tr.setMeta("rebased", nUnconfirmed).setMeta("addToHistory", false).setMeta(collabKey, newCollabState)
+  return tr.setMeta("rebased", unconfirmed.length).setMeta("addToHistory", false).setMeta(collabKey, newCollabState)
 }
 
 // :: (state: EditorState) → ?{version: number, steps: [Step], clientID: union<number, string>, origins: [Transaction]}


### PR DESCRIPTION
As part of automatic testing, we have one test in which two users in two browsers try to write in the same document simultaneously and one of them tries to use the undo function. This threw several errors every now and then. Looking at the code here and in the history module [1], it seems that this rebase count it comes up with her is the number of unconfirmed steps it tries to rebase, whereas in the history module it relies on the actual number of steps that have been rebased. The number will be the same as long as all steps are successfully rebased, but the count is off if maybeStep fails. By returning the actual number of unconfirmed steps here, the error did not throw any more in a number of test runs.

[1] https://github.com/ProseMirror/prosemirror-history/blob/528b1e9fa4f393b4140c4ea67874625dedede8e1/src/history.js#L140