### PR TITLE
Export collab plugin key

### DIFF
--- a/src/collab.js
+++ b/src/collab.js
@@ -56,7 +56,7 @@ function unconfirmedFrom(transform) {
   return result
 }
 
-const collabKey = new PluginKey("collab")
+export const collabKey = new PluginKey("collab")
 
 // :: (?Object) → Plugin
 //


### PR DESCRIPTION
This pr exports the collab plugin key from the collab module.

Having direct access to the plugin key is useful in several scenarios:
- You want to see whether the collab plugin is already present in the editor
- You want to access a piece of plugin state aside from version
- You want to debug the state of a plugin that’s already been initialized

In my project we fall under the first bullet above. The collab plugin gets initialized after the initial call to `EditorState.create` and we are trying to derive another piece of state based on whether it is present or not.