### PR TITLE
fixing a typo

### DIFF
--- a/src/collab.js
+++ b/src/collab.js
@@ -142,7 +142,7 @@ export function receiveTransaction(state, steps, clientIDs, options) {
   }
 
   let newCollabState = new CollabState(version, unconfirmed)
-  if (options && options.mapSelectionBackard && state.selection instanceof TextSelection) {
+  if (options && options.mapSelectionBackward && state.selection instanceof TextSelection) {
     tr.setSelection(TextSelection.between(tr.doc.resolve(tr.mapping.map(state.selection.head, -1)),
                                           tr.doc.resolve(tr.mapping.map(state.selection.anchor, -1)), -1))
     tr.updated &= ~1


### PR DESCRIPTION
...where the documentation doesn't match the signature of the options hash