### PR TITLE
bump mocha to 9.x and ensure lockfiles aren't created

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -20,14 +20,16 @@
     "prosemirror-state": "^1.0.0"
   },
   "devDependencies": {
+    "@rollup/plugin-buble": "^0.21.3",
     "ist": "^1.0.0",
-    "mocha": "^3.0.2",
+    "mocha": "^9.1.2",
     "prosemirror-history": "^1.0.0",
     "prosemirror-model": "^1.0.0",
+    "prosemirror-schema-basic": "^1.1.2",
+    "prosemirror-schema-list": "^1.1.6",
     "prosemirror-test-builder": "^1.0.0",
     "prosemirror-transform": "^1.0.0",
-    "rollup": "^2.26.3",
-    "@rollup/plugin-buble": "^0.21.3"
+    "rollup": "^2.26.3"
   },
   "scripts": {
     "test": "mocha test/test-*.js",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "mocha": "^9.1.2",
     "prosemirror-history": "^1.0.0",
     "prosemirror-model": "^1.0.0",
-    "prosemirror-schema-basic": "^1.1.2",
-    "prosemirror-schema-list": "^1.1.6",
     "prosemirror-test-builder": "^1.0.0",
     "prosemirror-transform": "^1.0.0",
     "rollup": "^2.26.3"


### PR DESCRIPTION
i'm working on tracking down an error in prosemirror-collab and in the interim i noticed that a few more dependencies are needed to ensure a clean `npm i && npm test`.

* add `prosemirror-schema-basic`
* add `prosemirror-schema-list`
* bump mocha to 9.x to resolve a possible security vulnerability
* ensure that a package-lock.json file isn't created on `npm install` since you don't check them into version control.

happy to walk any of the individual items above back if they aren't desired. thanks for all your work on this project! 🥇 