### PR TITLE
account for possible step application failure during rebase

### DIFF
--- a/src/collab.ts
+++ b/src/collab.ts
@@ -18,9 +18,15 @@ export function rebaseSteps(steps: readonly Rebaseable[], over: readonly Step[],
   for (let i = 0, mapFrom = steps.length; i < steps.length; i++) {
     let mapped = steps[i].step.map(transform.mapping.slice(mapFrom))
     mapFrom--
-    if (mapped && !transform.maybeStep(mapped).failed) {
-      transform.mapping.setMirror(mapFrom, transform.steps.length - 1)
-      result.push(new Rebaseable(mapped, mapped.invert(transform.docs[transform.docs.length - 1]), steps[i].origin))
+    if (mapped) {
+      try {
+        if (!transform.maybeStep(mapped).failed) {
+          transform.mapping.setMirror(mapFrom, transform.steps.length - 1)
+          result.push(new Rebaseable(mapped, mapped.invert(transform.docs[transform.docs.length - 1]), steps[i].origin))
+        }
+      } catch {
+        // if applying a step induces an error, omit it from the result
+      }
     }
   }
   return result


### PR DESCRIPTION
hi @marijnh 👋 

we intermittently see steps which can be applied cleanly locally, but induce an error when rebased on top of remote confirmed steps.

i am aware that `maybeStep()` possibly throwing is [by design](https://github.com/ProseMirror/prosemirror/issues/873). locally i'm seeing desirable behavior with the patch here, which simply ignores the failed steps altogether.

things i'm unsure of:
1. does more need to be done to purge these failed steps from any other unconfirmed steps that may be present?
1. is there something i could be doing outside of the collab plugin to make these steps more invertable/rebasable?

i haven't been able to isolate a simplified repro case for this error yet but i'm happy to describe the scenario in more detail if it would be helpful. the short version is (unsurprisingly), 'its complicated' :upside_down_face:

fwiw, with the same code, we're seeing this error orders of magnitude more frequently in prosemirror-transform@1.8.0 than prosemirror-transform@1.4.2